### PR TITLE
Work on Virtual Views

### DIFF
--- a/com.mindoo.domino.jna.xsp-feature/feature.xml
+++ b/com.mindoo.domino.jna.xsp-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.mindoo.domino.jna.xsp_feature"
       label="Domino JNA XPages Integrator Feature"
-      version="0.9.50.qualifier"
+      version="0.9.51.qualifier"
       provider-name="Mindoo GmbH">
 
    <description url="https://github.com/klehmann/domino-jna">Java project to access the HCL Domino C API using Java Native Access (JNA)</description>

--- a/com.mindoo.domino.jna.xsp-feature/feature.xml
+++ b/com.mindoo.domino.jna.xsp-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.mindoo.domino.jna.xsp_feature"
       label="Domino JNA XPages Integrator Feature"
-      version="0.9.49.qualifier"
+      version="0.9.50.qualifier"
       provider-name="Mindoo GmbH">
 
    <description url="https://github.com/klehmann/domino-jna">Java project to access the HCL Domino C API using Java Native Access (JNA)</description>

--- a/com.mindoo.domino.jna.xsp-feature/pom.xml
+++ b/com.mindoo.domino.jna.xsp-feature/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.mindoo.domino</groupId>
 		<artifactId>domino-jna-xsp-build</artifactId>
-		<version>0.9.50-SNAPSHOT</version>
+		<version>0.9.51-SNAPSHOT</version>
 		<relativePath>../com.mindoo.domino.jna.xsp.build</relativePath>
 	</parent>
 	<packaging>eclipse-feature</packaging>

--- a/com.mindoo.domino.jna.xsp-feature/pom.xml
+++ b/com.mindoo.domino.jna.xsp-feature/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.mindoo.domino</groupId>
 		<artifactId>domino-jna-xsp-build</artifactId>
-		<version>0.9.49-SNAPSHOT</version>
+		<version>0.9.50-SNAPSHOT</version>
 		<relativePath>../com.mindoo.domino.jna.xsp.build</relativePath>
 	</parent>
 	<packaging>eclipse-feature</packaging>

--- a/com.mindoo.domino.jna.xsp-updatesite/build.xml
+++ b/com.mindoo.domino.jna.xsp-updatesite/build.xml
@@ -14,11 +14,11 @@
 					<manifest>
 						<attribute name="Manifest-Version" value="1.0" />
 						<attribute name="Bundle-Vendor" value="Mindoo GmbH" />
-						<attribute name="Bundle-Version" value="0.9.50.${build_timestamp}" />
+						<attribute name="Bundle-Version" value="0.9.51.${build_timestamp}" />
 						<attribute name="Bundle-Name" value="Domino JNA XSP Integrator Plugin Source" />
 						<attribute name="Bundle-ManifestVersion" value="2" />
 						<attribute name="Bundle-SymbolicName" value="com.mindoo.domino.jna.xsp.source" />
-						<attribute name="Eclipse-SourceBundle" value="com.mindoo.domino.jna.xsp;version=&quot;0.9.50.${build_timestamp}&quot;;roots:=&quot;jna-src&quot;" />
+						<attribute name="Eclipse-SourceBundle" value="com.mindoo.domino.jna.xsp;version=&quot;0.9.51.${build_timestamp}&quot;;roots:=&quot;jna-src&quot;" />
 					</manifest>
 				</jar>
 			</sequential>

--- a/com.mindoo.domino.jna.xsp-updatesite/build.xml
+++ b/com.mindoo.domino.jna.xsp-updatesite/build.xml
@@ -14,11 +14,11 @@
 					<manifest>
 						<attribute name="Manifest-Version" value="1.0" />
 						<attribute name="Bundle-Vendor" value="Mindoo GmbH" />
-						<attribute name="Bundle-Version" value="0.9.49.${build_timestamp}" />
+						<attribute name="Bundle-Version" value="0.9.50.${build_timestamp}" />
 						<attribute name="Bundle-Name" value="Domino JNA XSP Integrator Plugin Source" />
 						<attribute name="Bundle-ManifestVersion" value="2" />
 						<attribute name="Bundle-SymbolicName" value="com.mindoo.domino.jna.xsp.source" />
-						<attribute name="Eclipse-SourceBundle" value="com.mindoo.domino.jna.xsp;version=&quot;0.9.49.${build_timestamp}&quot;;roots:=&quot;jna-src&quot;" />
+						<attribute name="Eclipse-SourceBundle" value="com.mindoo.domino.jna.xsp;version=&quot;0.9.50.${build_timestamp}&quot;;roots:=&quot;jna-src&quot;" />
 					</manifest>
 				</jar>
 			</sequential>

--- a/com.mindoo.domino.jna.xsp-updatesite/pom.xml
+++ b/com.mindoo.domino.jna.xsp-updatesite/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.mindoo.domino</groupId>
 		<artifactId>domino-jna-xsp-build</artifactId>
-		<version>0.9.49-SNAPSHOT</version>
+		<version>0.9.50-SNAPSHOT</version>
 		<relativePath>../com.mindoo.domino.jna.xsp.build</relativePath>
 	</parent>
 

--- a/com.mindoo.domino.jna.xsp-updatesite/pom.xml
+++ b/com.mindoo.domino.jna.xsp-updatesite/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.mindoo.domino</groupId>
 		<artifactId>domino-jna-xsp-build</artifactId>
-		<version>0.9.50-SNAPSHOT</version>
+		<version>0.9.51-SNAPSHOT</version>
 		<relativePath>../com.mindoo.domino.jna.xsp.build</relativePath>
 	</parent>
 

--- a/com.mindoo.domino.jna.xsp-updatesite/site.xml
+++ b/com.mindoo.domino.jna.xsp-updatesite/site.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/com.mindoo.domino.jna.xsp_feature_0.9.50.qualifier.jar" id="com.mindoo.domino.jna.xsp_feature" version="0.9.50.qualifier">
+   <feature url="features/com.mindoo.domino.jna.xsp_feature_0.9.51.qualifier.jar" id="com.mindoo.domino.jna.xsp_feature" version="0.9.51.qualifier">
       <category name="Mindoo"/>
    </feature>
    <category-def name="Mindoo" label="Mindoo"/>

--- a/com.mindoo.domino.jna.xsp-updatesite/site.xml
+++ b/com.mindoo.domino.jna.xsp-updatesite/site.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/com.mindoo.domino.jna.xsp_feature_0.9.49.qualifier.jar" id="com.mindoo.domino.jna.xsp_feature" version="0.9.49.qualifier">
+   <feature url="features/com.mindoo.domino.jna.xsp_feature_0.9.50.qualifier.jar" id="com.mindoo.domino.jna.xsp_feature" version="0.9.50.qualifier">
       <category name="Mindoo"/>
    </feature>
    <category-def name="Mindoo" label="Mindoo"/>

--- a/com.mindoo.domino.jna.xsp.build/pom.xml
+++ b/com.mindoo.domino.jna.xsp.build/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.mindoo.domino</groupId>
 		<artifactId>domino-jna-base</artifactId>
-		<version>0.9.49-SNAPSHOT</version>
+		<version>0.9.50-SNAPSHOT</version>
 	</parent>
 	
 	<properties>

--- a/com.mindoo.domino.jna.xsp.build/pom.xml
+++ b/com.mindoo.domino.jna.xsp.build/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.mindoo.domino</groupId>
 		<artifactId>domino-jna-base</artifactId>
-		<version>0.9.50-SNAPSHOT</version>
+		<version>0.9.51-SNAPSHOT</version>
 	</parent>
 	
 	<properties>

--- a/com.mindoo.domino.jna.xsp.source/META-INF/MANIFEST.MF
+++ b/com.mindoo.domino.jna.xsp.source/META-INF/MANIFEST.MF
@@ -2,5 +2,5 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Domino JNA XSP Integrator Plugin Source
 Bundle-SymbolicName: com.mindoo.domino.jna.xsp.source
-Bundle-Version: 0.9.50.qualifier
+Bundle-Version: 0.9.51.qualifier
 Bundle-Vendor: Mindoo GmbH

--- a/com.mindoo.domino.jna.xsp.source/META-INF/MANIFEST.MF
+++ b/com.mindoo.domino.jna.xsp.source/META-INF/MANIFEST.MF
@@ -2,5 +2,5 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Domino JNA XSP Integrator Plugin Source
 Bundle-SymbolicName: com.mindoo.domino.jna.xsp.source
-Bundle-Version: 0.9.49.qualifier
+Bundle-Version: 0.9.50.qualifier
 Bundle-Vendor: Mindoo GmbH

--- a/com.mindoo.domino.jna.xsp.source/pom.xml
+++ b/com.mindoo.domino.jna.xsp.source/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.mindoo.domino</groupId>
 		<artifactId>domino-jna-xsp-build</artifactId>
-		<version>0.9.50-SNAPSHOT</version>
+		<version>0.9.51-SNAPSHOT</version>
 		<relativePath>../com.mindoo.domino.jna.xsp.build</relativePath>
 	</parent>
 

--- a/com.mindoo.domino.jna.xsp.source/pom.xml
+++ b/com.mindoo.domino.jna.xsp.source/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.mindoo.domino</groupId>
 		<artifactId>domino-jna-xsp-build</artifactId>
-		<version>0.9.49-SNAPSHOT</version>
+		<version>0.9.50-SNAPSHOT</version>
 		<relativePath>../com.mindoo.domino.jna.xsp.build</relativePath>
 	</parent>
 

--- a/com.mindoo.domino.jna.xsp/META-INF/MANIFEST.MF
+++ b/com.mindoo.domino.jna.xsp/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-ActivationPolicy: lazy
 Bundle-Name: Domino JNA XSP Integrator Plugin
 Bundle-SymbolicName: com.mindoo.domino.jna.xsp;singleton:=true
-Bundle-Version: 0.9.50.qualifier
+Bundle-Version: 0.9.51.qualifier
 Bundle-Vendor: Mindoo GmbH
 Import-Package: com.ibm.designer.runtime.domino.adapter,
  com.ibm.designer.runtime.domino.bootstrap.adapter,

--- a/com.mindoo.domino.jna.xsp/META-INF/MANIFEST.MF
+++ b/com.mindoo.domino.jna.xsp/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-ActivationPolicy: lazy
 Bundle-Name: Domino JNA XSP Integrator Plugin
 Bundle-SymbolicName: com.mindoo.domino.jna.xsp;singleton:=true
-Bundle-Version: 0.9.49.qualifier
+Bundle-Version: 0.9.50.qualifier
 Bundle-Vendor: Mindoo GmbH
 Import-Package: com.ibm.designer.runtime.domino.adapter,
  com.ibm.designer.runtime.domino.bootstrap.adapter,

--- a/com.mindoo.domino.jna.xsp/pom.xml
+++ b/com.mindoo.domino.jna.xsp/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.mindoo.domino</groupId>
 		<artifactId>domino-jna-xsp-build</artifactId>
-		<version>0.9.49-SNAPSHOT</version>
+		<version>0.9.50-SNAPSHOT</version>
 		<relativePath>../com.mindoo.domino.jna.xsp.build</relativePath>
 	</parent>
 

--- a/com.mindoo.domino.jna.xsp/pom.xml
+++ b/com.mindoo.domino.jna.xsp/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.mindoo.domino</groupId>
 		<artifactId>domino-jna-xsp-build</artifactId>
-		<version>0.9.50-SNAPSHOT</version>
+		<version>0.9.51-SNAPSHOT</version>
 		<relativePath>../com.mindoo.domino.jna.xsp.build</relativePath>
 	</parent>
 

--- a/com.sun.jna/pom.xml
+++ b/com.sun.jna/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.mindoo.domino</groupId>
 		<artifactId>domino-jna-xsp-build</artifactId>
-		<version>0.9.49-SNAPSHOT</version>
+		<version>0.9.50-SNAPSHOT</version>
 		<relativePath>../com.mindoo.domino.jna.xsp.build</relativePath>
 	</parent>
 

--- a/com.sun.jna/pom.xml
+++ b/com.sun.jna/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.mindoo.domino</groupId>
 		<artifactId>domino-jna-xsp-build</artifactId>
-		<version>0.9.50-SNAPSHOT</version>
+		<version>0.9.51-SNAPSHOT</version>
 		<relativePath>../com.mindoo.domino.jna.xsp.build</relativePath>
 	</parent>
 

--- a/domino-jna-indexer-cqengine/.classpath
+++ b/domino-jna-indexer-cqengine/.classpath
@@ -9,19 +9,7 @@
 	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
-		<attributes>
 			<attribute name="optional" value="true"/>
-			<attribute name="maven.pomderived" value="true"/>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
-		<attributes>
-			<attribute name="maven.pomderived" value="true"/>
-			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">

--- a/domino-jna-indexer-cqengine/pom.xml
+++ b/domino-jna-indexer-cqengine/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.mindoo.domino</groupId>
 		<artifactId>domino-jna-base</artifactId>
-		<version>0.9.50-SNAPSHOT</version>
+		<version>0.9.51-SNAPSHOT</version>
 	</parent>
 
 	<name>Domino JNA Add-on for data indexing with CQEngine</name>

--- a/domino-jna-indexer-cqengine/pom.xml
+++ b/domino-jna-indexer-cqengine/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.mindoo.domino</groupId>
 		<artifactId>domino-jna-base</artifactId>
-		<version>0.9.49-SNAPSHOT</version>
+		<version>0.9.50-SNAPSHOT</version>
 	</parent>
 
 	<name>Domino JNA Add-on for data indexing with CQEngine</name>

--- a/domino-jna-indexer-sql/.classpath
+++ b/domino-jna-indexer-sql/.classpath
@@ -9,19 +9,7 @@
 	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
-		<attributes>
 			<attribute name="optional" value="true"/>
-			<attribute name="maven.pomderived" value="true"/>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
-		<attributes>
-			<attribute name="maven.pomderived" value="true"/>
-			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">

--- a/domino-jna-indexer-sql/pom.xml
+++ b/domino-jna-indexer-sql/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.mindoo.domino</groupId>
 		<artifactId>domino-jna-base</artifactId>
-		<version>0.9.50-SNAPSHOT</version>
+		<version>0.9.51-SNAPSHOT</version>
 	</parent>
 
 	<name>Domino JNA Add-on for data indexing with SQL</name>

--- a/domino-jna-indexer-sql/pom.xml
+++ b/domino-jna-indexer-sql/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.mindoo.domino</groupId>
 		<artifactId>domino-jna-base</artifactId>
-		<version>0.9.49-SNAPSHOT</version>
+		<version>0.9.50-SNAPSHOT</version>
 	</parent>
 
 	<name>Domino JNA Add-on for data indexing with SQL</name>

--- a/domino-jna-indexer-sqlite/.classpath
+++ b/domino-jna-indexer-sqlite/.classpath
@@ -9,19 +9,7 @@
 	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
-		<attributes>
 			<attribute name="optional" value="true"/>
-			<attribute name="maven.pomderived" value="true"/>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
-		<attributes>
-			<attribute name="maven.pomderived" value="true"/>
-			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">

--- a/domino-jna-indexer-sqlite/pom.xml
+++ b/domino-jna-indexer-sqlite/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.mindoo.domino</groupId>
 		<artifactId>domino-jna-base</artifactId>
-		<version>0.9.49-SNAPSHOT</version>
+		<version>0.9.50-SNAPSHOT</version>
 	</parent>
 
 	<name>Domino JNA Add-on for data indexing with SQLite</name>

--- a/domino-jna-indexer-sqlite/pom.xml
+++ b/domino-jna-indexer-sqlite/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.mindoo.domino</groupId>
 		<artifactId>domino-jna-base</artifactId>
-		<version>0.9.50-SNAPSHOT</version>
+		<version>0.9.51-SNAPSHOT</version>
 	</parent>
 
 	<name>Domino JNA Add-on for data indexing with SQLite</name>

--- a/domino-jna-mime-jakartamail/pom.xml
+++ b/domino-jna-mime-jakartamail/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.mindoo.domino</groupId>
 		<artifactId>domino-jna-base</artifactId>
-		<version>0.9.50-SNAPSHOT</version>
+		<version>0.9.51-SNAPSHOT</version>
 	</parent>
 
 	<name>Domino JNA Jakarta Mail Connector</name>

--- a/domino-jna-mime-jakartamail/pom.xml
+++ b/domino-jna-mime-jakartamail/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.mindoo.domino</groupId>
 		<artifactId>domino-jna-base</artifactId>
-		<version>0.9.49-SNAPSHOT</version>
+		<version>0.9.50-SNAPSHOT</version>
 	</parent>
 
 	<name>Domino JNA Jakarta Mail Connector</name>

--- a/domino-jna-mime-javaxmail/pom.xml
+++ b/domino-jna-mime-javaxmail/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.mindoo.domino</groupId>
 		<artifactId>domino-jna-base</artifactId>
-		<version>0.9.50-SNAPSHOT</version>
+		<version>0.9.51-SNAPSHOT</version>
 	</parent>
 
 	<name>Domino JNA Javax Mail Connector</name>

--- a/domino-jna-mime-javaxmail/pom.xml
+++ b/domino-jna-mime-javaxmail/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.mindoo.domino</groupId>
 		<artifactId>domino-jna-base</artifactId>
-		<version>0.9.49-SNAPSHOT</version>
+		<version>0.9.50-SNAPSHOT</version>
 	</parent>
 
 	<name>Domino JNA Javax Mail Connector</name>

--- a/domino-jna-mime-mime4j/pom.xml
+++ b/domino-jna-mime-mime4j/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.mindoo.domino</groupId>
 		<artifactId>domino-jna-base</artifactId>
-		<version>0.9.49-SNAPSHOT</version>
+		<version>0.9.50-SNAPSHOT</version>
 	</parent>
 
 	<name>Domino JNA MIME4J Mail Connector</name>

--- a/domino-jna-mime-mime4j/pom.xml
+++ b/domino-jna-mime-mime4j/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.mindoo.domino</groupId>
 		<artifactId>domino-jna-base</artifactId>
-		<version>0.9.50-SNAPSHOT</version>
+		<version>0.9.51-SNAPSHOT</version>
 	</parent>
 
 	<name>Domino JNA MIME4J Mail Connector</name>

--- a/domino-jna/pom.xml
+++ b/domino-jna/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.mindoo.domino</groupId>
 		<artifactId>domino-jna-base</artifactId>
-		<version>0.9.49-SNAPSHOT</version>
+		<version>0.9.50-SNAPSHOT</version>
 	</parent>
 
 	<name>Domino JNA</name>

--- a/domino-jna/pom.xml
+++ b/domino-jna/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.mindoo.domino</groupId>
 		<artifactId>domino-jna-base</artifactId>
-		<version>0.9.50-SNAPSHOT</version>
+		<version>0.9.51-SNAPSHOT</version>
 	</parent>
 
 	<name>Domino JNA</name>
@@ -84,7 +84,7 @@
 						<configuration>
 							<serverId>nexus-releases</serverId>
 							<nexusUrl>https://oss.sonatype.org/</nexusUrl>
-							<autoReleaseAfterClose>true</autoReleaseAfterClose>
+							<!--<autoReleaseAfterClose>true</autoReleaseAfterClose>-->
 							<!-- explicit matching using the staging profile id -->
 							<!-- <stagingProfileId>49650ad66a37c6</stagingProfileId> -->
 						</configuration>

--- a/domino-jna/src/main/java/com/mindoo/domino/jna/IViewEntryData.java
+++ b/domino-jna/src/main/java/com/mindoo/domino/jna/IViewEntryData.java
@@ -55,4 +55,13 @@ public interface IViewEntryData extends INoteSummary {
 	 * @return level
 	 */
 	int getLevel();
+	
+	/**
+	 * For category entries where the category contains a "\" character, this method returns the
+	 * index of the category entry (e.g. 1 for "level2" in the string "level1\level2").
+	 * 
+	 * @return indent level
+	 */
+	int getIndentLevels();
+	
 }

--- a/domino-jna/src/main/java/com/mindoo/domino/jna/NotesDatabase.java
+++ b/domino-jna/src/main/java/com/mindoo/domino/jna/NotesDatabase.java
@@ -2306,7 +2306,7 @@ public class NotesDatabase implements IRecyclableNotesObject, IAdaptable {
 	 * @param retUntil A pointer to a {@link NotesTimeDate} structure into which the ending time of this search will be returned.  This can subsequently be used as the starting time in a later search.
 	 * @return newly allocated ID Table, you are responsible for freeing the storage when you are done with it using {@link NotesIDTable#recycle()}
 	 */
-	public NotesIDTable getModifiedNoteTable(EnumSet<NoteClass> noteClassMaskEnum, NotesTimeDate since, NotesTimeDate retUntil) {
+	public NotesIDTable getModifiedNoteTable(Set<NoteClass> noteClassMaskEnum, NotesTimeDate since, NotesTimeDate retUntil) {
 		short noteClassMask = NoteClass.toBitMask(noteClassMaskEnum);
 
 		return getModifiedNoteTable(noteClassMask, since, retUntil);

--- a/domino-jna/src/main/java/com/mindoo/domino/jna/NotesViewEntryData.java
+++ b/domino-jna/src/main/java/com/mindoo/domino/jna/NotesViewEntryData.java
@@ -446,11 +446,14 @@ public class NotesViewEntryData extends TypedItemAccess implements IViewEntryDat
 	}
 
 	/**
-	 * Returns the indent levels in the view. Only returns a value if {@link ReadMask#INDENTLEVELS}
-	 * is used for the lookup
+	 * For category entries where the category contains a "\" character, this method returns the
+	 * index of the category entry (e.g. 1 for "level2" in the string "level1\level2").<br>
+	 * <br>
+	 * Only returns a value if {@link ReadMask#INDENTLEVELS} is used for the lookup.
 	 * 
 	 * @return levels or 0
 	 */
+	@Override
 	public int getIndentLevels() {
 		return m_indentLevels!=null ? m_indentLevels.intValue() : 0;
 	}

--- a/domino-jna/src/main/java/com/mindoo/domino/jna/utils/NotesMarkdownTable.java
+++ b/domino-jna/src/main/java/com/mindoo/domino/jna/utils/NotesMarkdownTable.java
@@ -469,7 +469,7 @@ public class NotesMarkdownTable {
 	/**
 	 * Table column for the child count of the view entry
 	 */
-	public static final ColumnInfo CHILDCOUNT = new ColumnInfo("ChildCount", 12, (table, entry) -> {
+	public static final ColumnInfo CHILDCOUNT = new ColumnInfo("ChildCount", 10, (table, entry) -> {
 		return Integer.toString(entry.getChildCount());
 	});
 	
@@ -483,8 +483,15 @@ public class NotesMarkdownTable {
 	/**
 	 * Table column for the descendant count of the view entry
 	 */
-	public static final ColumnInfo DESCENDANTCOUNT = new ColumnInfo("DescendantCount", 12, (table, entry) -> {
+	public static final ColumnInfo DESCENDANTCOUNT = new ColumnInfo("DescendantCount", 15, (table, entry) -> {
 		return Integer.toString(entry.getDescendantCount());
+	});
+
+	/**
+	 * Table column for the indent levels of the view entry
+	 */
+	public static final ColumnInfo INDENTLEVELS = new ColumnInfo("IndentLevels", 12, (table, entry) -> {
+		return Integer.toString(entry.getIndentLevels());
 	});
 
 	/**
@@ -566,6 +573,8 @@ public class NotesMarkdownTable {
 				if (entry.isCategory()) {
 					String sVal;
 					int level = entry.getLevel();
+					int indentLevel = entry.getIndentLevels();
+					
 					if (table.m_realView != null) {
 						if (level == -1) {
 							//ReadMask.INDEX_POSITION not loaded from view
@@ -582,9 +591,8 @@ public class NotesMarkdownTable {
 							//for virtual views, -1 means the artificial root entry
 							return "";
 						}
-						VirtualViewColumn col = table.m_virtualView.getColumns().get(level);
-						Object categoryVal = entry.get(col.getItemName());
-						sVal = StringUtil.repeat(' ', level) + String.valueOf(categoryVal);
+						Object categoryVal = ((VirtualViewEntryData)entry).getCategoryValue();
+						sVal = StringUtil.repeat(' ', level + indentLevel) + String.valueOf(categoryVal);
 					}
 					if (StringUtil.isEmpty(sVal)) {
 						sVal = "(not categorized)";

--- a/domino-jna/src/main/java/com/mindoo/domino/jna/utils/NotesMarkdownTable.java
+++ b/domino-jna/src/main/java/com/mindoo/domino/jna/utils/NotesMarkdownTable.java
@@ -591,7 +591,7 @@ public class NotesMarkdownTable {
 								}
 							}
 						}
-						if (categoryVal == null) {
+						if (categoryVal == null || "".equals(categoryVal)) {
 							categoryVal = "(Not categorized)";
 						}
 						sVal = StringUtil.repeat(' ', level + indentLevels) + String.valueOf(categoryVal);
@@ -602,7 +602,7 @@ public class NotesMarkdownTable {
 							return "";
 						}
 						Object categoryVal = ((VirtualViewEntryData)entry).getCategoryValue();
-						if (categoryVal == null) {
+						if (categoryVal == null || "".equals(categoryVal)) {
 							categoryVal = "(Not categorized)";
 						}
 						sVal = StringUtil.repeat(' ', level + indentLevels) + String.valueOf(categoryVal);

--- a/domino-jna/src/main/java/com/mindoo/domino/jna/utils/NotesMarkdownTable.java
+++ b/domino-jna/src/main/java/com/mindoo/domino/jna/utils/NotesMarkdownTable.java
@@ -573,18 +573,28 @@ public class NotesMarkdownTable {
 				if (entry.isCategory()) {
 					String sVal;
 					int level = entry.getLevel();
-					int indentLevel = entry.getIndentLevels();
+					int indentLevels = entry.getIndentLevels();
 					
 					if (table.m_realView != null) {
 						if (level == -1) {
 							//ReadMask.INDEX_POSITION not loaded from view
 							return "(no index position found)";
 						}
-						int indentLevels = ((NotesViewEntryData)entry).getIndentLevels();
 
-						NotesViewColumn col = table.m_realView.getColumns().get(level);
-						Object categoryVal = entry.get(col.getItemName());
-						sVal = StringUtil.repeat(' ', level) + String.valueOf(categoryVal);
+						Object categoryVal = null;
+						for (int i=table.m_realView.getColumns().size()-1; i>=0; i--) {
+							NotesViewColumn col = table.m_realView.getColumns().get(i);
+							if (col.isCategory()) {
+								categoryVal = entry.get(col.getItemName());
+								if (categoryVal != null) {
+									break;
+								}
+							}
+						}
+						if (categoryVal == null) {
+							categoryVal = "(Not categorized)";
+						}
+						sVal = StringUtil.repeat(' ', level + indentLevels) + String.valueOf(categoryVal);
 					}
 					else {
 						if (level == -1) {
@@ -592,10 +602,10 @@ public class NotesMarkdownTable {
 							return "";
 						}
 						Object categoryVal = ((VirtualViewEntryData)entry).getCategoryValue();
-						sVal = StringUtil.repeat(' ', level + indentLevel) + String.valueOf(categoryVal);
-					}
-					if (StringUtil.isEmpty(sVal)) {
-						sVal = "(not categorized)";
+						if (categoryVal == null) {
+							categoryVal = "(Not categorized)";
+						}
+						sVal = StringUtil.repeat(' ', level + indentLevels) + String.valueOf(categoryVal);
 					}
 					return sVal;
 				}

--- a/domino-jna/src/main/java/com/mindoo/domino/jna/virtualviews/ViewEntrySortKeyComparator.java
+++ b/domino-jna/src/main/java/com/mindoo/domino/jna/virtualviews/ViewEntrySortKeyComparator.java
@@ -3,16 +3,18 @@ package com.mindoo.domino.jna.virtualviews;
 import java.util.Comparator;
 import java.util.List;
 
-import com.mindoo.domino.jna.NotesTimeDate;
+import com.mindoo.domino.jna.virtualviews.VirtualView.CategorizationStyle;
 
 /**
  * Comparator to sort {@link ViewEntrySortKey} objects within one level of the {@link VirtualView} tree structure
  */
 public class ViewEntrySortKeyComparator implements Comparator<ViewEntrySortKey> {
+	private boolean categoriesOnTopOfDocuments;
 	private boolean categoryOrderDescending;
 	private boolean[] docOrderPerColumnDescending;
 	
-	public ViewEntrySortKeyComparator(boolean categoryOrderDescending, boolean[] docOrderDescending) {
+	public ViewEntrySortKeyComparator(CategorizationStyle categorizationStyle, boolean categoryOrderDescending, boolean[] docOrderDescending) {
+		this.categoriesOnTopOfDocuments = categorizationStyle == CategorizationStyle.CATEGORY_THEN_DOCUMENT;
 		this.categoryOrderDescending = categoryOrderDescending;
 		this.docOrderPerColumnDescending = docOrderDescending;
 	}
@@ -118,14 +120,14 @@ public class ViewEntrySortKeyComparator implements Comparator<ViewEntrySortKey> 
 				}
 			}
 			else {
-				//sort category above document
-				return -1;
+				//sort category above/below document
+				return categoriesOnTopOfDocuments ? -1 : 1;
 			}
 		}
 		else {
 			if (isCategory2) {
-				//sort document below category
-				return 1;
+				//sort document below/above category
+				return categoriesOnTopOfDocuments ? 1 : -1;
 			}
 			else {
 				//both are no categories, fall through to sort by values

--- a/domino-jna/src/main/java/com/mindoo/domino/jna/virtualviews/ViewEntrySortKeyComparator.java
+++ b/domino-jna/src/main/java/com/mindoo/domino/jna/virtualviews/ViewEntrySortKeyComparator.java
@@ -212,17 +212,8 @@ public class ViewEntrySortKeyComparator implements Comparator<ViewEntrySortKey> 
 						int result = ((Comparable)currValue1).compareTo((Comparable)currValue2);
 						
 						if (result != 0) {
-							return categoryOrderDescending ? -result : result;
+							return docOrderPerColumnDescending[i] ? -result : result;
 						}
-
-//					} else if (currValue1 instanceof NotesTimeDate && currValue2 instanceof NotesTimeDate) {
-//						NotesTimeDate time1 = (NotesTimeDate) currValue1;
-//						NotesTimeDate time2 = (NotesTimeDate) currValue2;
-//						
-//						int result = time1.compareTo(time2);
-//						if (result != 0) {
-//							return docOrderPerColumnDescending[i] ? -result : result;
-//						}
 					} else {
 						String class1 = currValue1 != null ? currValue1.getClass().getName() : "null";
 						String class2 = currValue2 != null ? currValue2.getClass().getName() : "null";

--- a/domino-jna/src/main/java/com/mindoo/domino/jna/virtualviews/ViewEntrySortKeyComparator.java
+++ b/domino-jna/src/main/java/com/mindoo/domino/jna/virtualviews/ViewEntrySortKeyComparator.java
@@ -30,17 +30,17 @@ public class ViewEntrySortKeyComparator implements Comparator<ViewEntrySortKey> 
 				Object catVal1 = values1.get(0);
 				Object catVal2 = values2.get(0);
 				
-				//sort null category values on top ("(no category)")
+				//sort null category values to the bottom ("(Not categorized)")
 				if (catVal1 == null) {
 					if (catVal2 == null) {
 						return 0;
 					} else {
-						return categoryOrderDescending ? 1 : -1;
+						return categoryOrderDescending ? -1 : 1;
 					}
 				}
 				else {
 					if (catVal2 == null) {
-						return categoryOrderDescending ? -1 : 1;
+						return categoryOrderDescending ? 1 : -1;
 					}
 					else {
 						//special case, LOW_SORTVAL always on top; we use LOW_SORTVAL and HIGH_SORTVAL to select all categories or all documents
@@ -182,12 +182,12 @@ public class ViewEntrySortKeyComparator implements Comparator<ViewEntrySortKey> 
 				if (currValue2 == null) {
 					continue;
 				} else {
-					return docOrderPerColumnDescending[i] ? 1 : -1;
+					return docOrderPerColumnDescending[i] ? -1 : 1;
 				}
 			}
 			else {
 				if (currValue2 == null) {
-					return docOrderPerColumnDescending[i] ? -1 : 1;
+					return docOrderPerColumnDescending[i] ? 1 : -1;
 				}
 				else {
 					if (currValue1 instanceof String && currValue2 instanceof String) {

--- a/domino-jna/src/main/java/com/mindoo/domino/jna/virtualviews/ViewEntrySortKeyComparator.java
+++ b/domino-jna/src/main/java/com/mindoo/domino/jna/virtualviews/ViewEntrySortKeyComparator.java
@@ -96,17 +96,19 @@ public class ViewEntrySortKeyComparator implements Comparator<ViewEntrySortKey> 
 								return categoryOrderDescending ? -result : result;
 							}
 
-						} else if (catVal1 instanceof NotesTimeDate && catVal2 instanceof Comparable) {
-							NotesTimeDate time1 = (NotesTimeDate) catVal1;
-							NotesTimeDate time2 = (NotesTimeDate) catVal2;
-							int result = time1.compareTo(time2);
+						} else if (catVal1.getClass().equals(catVal2.getClass()) && catVal1 instanceof Comparable) {
+							int result = ((Comparable)catVal1).compareTo((Comparable)catVal2);
 							
 							if (result != 0) {
 								return categoryOrderDescending ? -result : result;
 							}
 
 						} else {
-							throw new IllegalArgumentException("Unsupported value type for category: " + catVal1.getClass());
+							String class1 = catVal1 != null ? catVal1.getClass().getName() : "null";
+							String class2 = catVal2 != null ? catVal2.getClass().getName() : "null";
+							
+							throw new IllegalArgumentException("Incompatible/unknown value types for category comparison: " +
+									"value1="+catVal1+" ("+class1+"), value2="+catVal2+" ("+class2+")");
 						}
 						
 						//category values are equal, now sort by origin and note id
@@ -169,6 +171,13 @@ public class ViewEntrySortKeyComparator implements Comparator<ViewEntrySortKey> 
 				return -1;
 			}
 
+			if ("".equals(currValue1)) {
+				currValue1 = null;
+			}
+			if ("".equals(currValue2)) {
+				currValue2 = null;
+			}
+			
 			if (currValue1 == null) {
 				if (currValue2 == null) {
 					continue;
@@ -197,38 +206,27 @@ public class ViewEntrySortKeyComparator implements Comparator<ViewEntrySortKey> 
 						if (result != 0) {
 							return docOrderPerColumnDescending[i] ? -result : result;
 						}
-					} else if (currValue1 instanceof NotesTimeDate && currValue2 instanceof NotesTimeDate) {
-						NotesTimeDate time1 = (NotesTimeDate) currValue1;
-						NotesTimeDate time2 = (NotesTimeDate) currValue2;
+					} else if (currValue1.getClass().equals(currValue2.getClass()) && currValue1 instanceof Comparable) {
+						int result = ((Comparable)currValue1).compareTo((Comparable)currValue2);
 						
-						// Ensure that we can compare the two temporals
-//						if (!o1.isSupported(ChronoField.INSTANT_SECONDS) || !o2.isSupported(ChronoField.INSTANT_SECONDS)) {
-//							throw new IllegalArgumentException("Both Temporals must support the INSTANT_SECONDS field for comparison");
-//						}
-//
-//						long epochSecond1 = o1.getLong(ChronoField.INSTANT_SECONDS);
-//						long epochSecond2 = o2.getLong(ChronoField.INSTANT_SECONDS);
-//
-//						// Compare the INSTANT_SECONDS, which represents the number of seconds from the Java epoch of 1970-01-01 (ISO).
-//						int compare = Long.compare(epochSecond1, epochSecond2);
-//
-//						if (compare != 0) {
-//							return compare;
-//						}
-//
-//						// If the INSTANT_SECONDS are equal, compare the nanosecond part.
-//						if (o1.isSupported(ChronoField.NANO_OF_SECOND) && o2.isSupported(ChronoField.NANO_OF_SECOND)) {
-//							int nanoOfSecond1 = o1.get(ChronoField.NANO_OF_SECOND);
-//							int nanoOfSecond2 = o2.get(ChronoField.NANO_OF_SECOND);
-//							return Integer.compare(nanoOfSecond1, nanoOfSecond2);
-//						}
-						
-						int result = time1.compareTo(time2);
 						if (result != 0) {
-							return docOrderPerColumnDescending[i] ? -result : result;
+							return categoryOrderDescending ? -result : result;
 						}
+
+//					} else if (currValue1 instanceof NotesTimeDate && currValue2 instanceof NotesTimeDate) {
+//						NotesTimeDate time1 = (NotesTimeDate) currValue1;
+//						NotesTimeDate time2 = (NotesTimeDate) currValue2;
+//						
+//						int result = time1.compareTo(time2);
+//						if (result != 0) {
+//							return docOrderPerColumnDescending[i] ? -result : result;
+//						}
 					} else {
-						throw new IllegalArgumentException("Unsupported value type " + currValue1.getClass());
+						String class1 = currValue1 != null ? currValue1.getClass().getName() : "null";
+						String class2 = currValue2 != null ? currValue2.getClass().getName() : "null";
+						
+						throw new IllegalArgumentException("Incompatible/unknown value types for document comparison: index= " + i+
+								", value1="+currValue1+" ("+class1+"), value2="+currValue2+" ("+class2+")");
 					}
 				}
 			}

--- a/domino-jna/src/main/java/com/mindoo/domino/jna/virtualviews/VirtualView.java
+++ b/domino-jna/src/main/java/com/mindoo/domino/jna/virtualviews/VirtualView.java
@@ -722,7 +722,7 @@ public class VirtualView {
 			}			
 		}
 	
-		return createdChildEntriesForDocument;
+		return Collections.unmodifiableList(createdChildEntriesForDocument);
 	}
 
 	private void addDocToCountsAndReadersListOfParents(VirtualViewEntryData docEntry) {
@@ -954,14 +954,7 @@ public class VirtualView {
 		
 	}
 	
-	/**
-	 * Returns all occurrences of a note id in the view
-	 * 
-	 * @param origin origin of the entry
-	 * @param noteId note id of the entry
-	 * @return list of entries
-	 */
-	public List<VirtualViewEntryData> findEntries(String origin, int noteId) {
-		return Collections.unmodifiableList(entriesByNoteId.get(new ScopedNoteId(origin, noteId)));
+	List<VirtualViewEntryData> getEntries(String origin, int noteId) {
+		return entriesByNoteId.getOrDefault(new ScopedNoteId(origin, noteId), Collections.emptyList());
 	}
 }

--- a/domino-jna/src/main/java/com/mindoo/domino/jna/virtualviews/VirtualView.java
+++ b/domino-jna/src/main/java/com/mindoo/domino/jna/virtualviews/VirtualView.java
@@ -77,7 +77,6 @@ public class VirtualView {
 	/**
 	 * Creates a new virtual view
 	 * 
-	 * @param categorizationStyle categorization style (whether categories are on top of documents or vice versa)
 	 * @param columnsParam columns of the view
 	 */
 	public VirtualView(List<VirtualViewColumn> columnsParam) {

--- a/domino-jna/src/main/java/com/mindoo/domino/jna/virtualviews/VirtualView.java
+++ b/domino-jna/src/main/java/com/mindoo/domino/jna/virtualviews/VirtualView.java
@@ -604,9 +604,9 @@ public class VirtualView {
 				
 				VirtualViewEntryData currentSubCatParent = targetParent;
 				
-				for (int i=0; i<parts.length; i++) {
-					String currSubCat = parts[i];
-					boolean isLastPart = i == parts.length-1;
+				for (int indentLevel=0; indentLevel<parts.length; indentLevel++) {
+					String currSubCat = parts[indentLevel];
+					boolean isLastPart = indentLevel == parts.length-1;
 					
 					Object currSubCatObj = "".equals(currSubCat) ? null : currSubCat;
 					
@@ -642,6 +642,7 @@ public class VirtualView {
 						if (currSubCatObj != null) {
 							categoryColValues.put(itemName, currSubCatObj);
 						}
+						entryWithSortKey.setIndentLevels(indentLevel);
 						entryWithSortKey.setColumnValues(categoryColValues);
 						
 						if (currentSubCatParent.getChildEntriesAsMap().put(categorySortKey, entryWithSortKey) == null) {

--- a/domino-jna/src/main/java/com/mindoo/domino/jna/virtualviews/VirtualViewEntryData.java
+++ b/domino-jna/src/main/java/com/mindoo/domino/jna/virtualviews/VirtualViewEntryData.java
@@ -33,6 +33,9 @@ public class VirtualViewEntryData extends TypedItemAccess implements IViewEntryD
 	private int level = Integer.MIN_VALUE;
 	private int indentLevels;
 	
+	private int[] pos;
+	private String posStr;
+	
 	private ViewEntrySortKey sortKey;	
 	private Map<String,Object> columnValues;
 	
@@ -285,7 +288,12 @@ public class VirtualViewEntryData extends TypedItemAccess implements IViewEntryD
 	}
 	
 	void setSiblingIndex(int idx) {
-		siblingIndex = idx;
+		if (siblingIndex != idx) {
+			siblingIndex = idx;
+			//reset cached values, because our index has changed
+			pos = null;
+			posStr = null;			
+		}
 	}
 	
 	void setIndentLevels(int level) {
@@ -304,16 +312,19 @@ public class VirtualViewEntryData extends TypedItemAccess implements IViewEntryD
 	 */
 	@Override
 	public String getPositionStr() {
-		int[] pos = getPosition();
-		StringBuilder sb = new StringBuilder();
-		for (int i=0; i<pos.length; i++) {
-			if (sb.length() > 0) {
-				sb.append('.');
+		if (posStr == null) {
+			int[] pos = getPosition();
+			StringBuilder sb = new StringBuilder();
+			for (int i=0; i<pos.length; i++) {
+				if (sb.length() > 0) {
+					sb.append('.');
+				}
+
+				sb.append(pos[i]);
 			}
-			
-			sb.append(pos[i]);
+			posStr = sb.toString();
 		}
-		return sb.toString();
+		return posStr;
 	}
 	
 	@Override
@@ -336,30 +347,33 @@ public class VirtualViewEntryData extends TypedItemAccess implements IViewEntryD
 	 */
 	@Override
 	public int[] getPosition() {
-		if (parentView.getRoot().equals(this)) {
-			return new int[] { 0 };
-		}
-		
-		LinkedList<Integer> pos = new LinkedList<>();
-		pos.add(getSiblingIndex());
-		
-		VirtualViewEntryData parentEntry = getParent();
-		while (parentEntry != null) {
-			int parentSiblingIdx = parentEntry.getSiblingIndex();
-			
-			parentEntry = parentEntry.getParent();
-			if (parentEntry != null) {
-				//ignore root sibling position
-				pos.addFirst(parentSiblingIdx);
+		if (pos == null) {
+			if (parentView.getRoot().equals(this)) {
+				pos = new int[] { 0 };
+			}
+			else {
+				LinkedList<Integer> posList = new LinkedList<>();
+				posList.add(getSiblingIndex());
+				
+				VirtualViewEntryData parentEntry = getParent();
+				while (parentEntry != null) {
+					int parentSiblingIdx = parentEntry.getSiblingIndex();
+					
+					parentEntry = parentEntry.getParent();
+					if (parentEntry != null) {
+						//ignore root sibling position
+						posList.addFirst(parentSiblingIdx);
+					}
+				}
+				
+				pos = new int[posList.size()];
+				int idx = 0;
+				for (Integer currPos : posList) {
+					pos[idx++] = currPos.intValue();
+				}
 			}
 		}
-		
-		int[] posArr = new int[pos.size()];
-		int idx = 0;
-		for (Integer currPos : pos) {
-			posArr[idx++] = currPos.intValue();
-		}
-		return posArr;
+		return pos;
 	}
 	
 	private ConcurrentHashMap<String,Double> totalValues = new ConcurrentHashMap<>();

--- a/domino-jna/src/main/java/com/mindoo/domino/jna/virtualviews/VirtualViewEntryData.java
+++ b/domino-jna/src/main/java/com/mindoo/domino/jna/virtualviews/VirtualViewEntryData.java
@@ -31,6 +31,7 @@ public class VirtualViewEntryData extends TypedItemAccess implements IViewEntryD
 	private String unid;
 	private int siblingIndex;
 	private int level = Integer.MIN_VALUE;
+	private int indentLevels;
 	
 	private ViewEntrySortKey sortKey;	
 	private Map<String,Object> columnValues;
@@ -285,6 +286,15 @@ public class VirtualViewEntryData extends TypedItemAccess implements IViewEntryD
 	
 	void setSiblingIndex(int idx) {
 		siblingIndex = idx;
+	}
+	
+	void setIndentLevels(int level) {
+		indentLevels = level;
+	}
+	
+	@Override
+	public int getIndentLevels() {
+		return indentLevels;
 	}
 	
 	/**

--- a/domino-jna/src/main/java/com/mindoo/domino/jna/virtualviews/VirtualViewFactory.java
+++ b/domino-jna/src/main/java/com/mindoo/domino/jna/virtualviews/VirtualViewFactory.java
@@ -70,6 +70,10 @@ public enum VirtualViewFactory {
 				.getColumns()
 				.stream()
 				.map((currCol) -> {
+					if (currCol.isResponse()) {
+						//skip response columns, unsupported
+						return null;
+					}
 					String title = currCol.getTitle();
 					String itemName = currCol.getItemName();
 					String formula = currCol.getFormula();
@@ -93,6 +97,7 @@ public enum VirtualViewFactory {
 					return new VirtualViewColumn(title, itemName, isCategory ? Category.YES : Category.NO, isHidden ? Hidden.YES : Hidden.NO, sort,
 							totalMode, formula);
                 })
+				.filter((currCol) -> currCol!=null)
 				.collect(Collectors.toList());
 		return new VirtualViewBuilder(virtualViewColumns);
 	}

--- a/domino-jna/src/main/java/com/mindoo/domino/jna/virtualviews/VirtualViewFactory.java
+++ b/domino-jna/src/main/java/com/mindoo/domino/jna/virtualviews/VirtualViewFactory.java
@@ -19,6 +19,7 @@ import com.mindoo.domino.jna.constants.FTSearch;
 import com.mindoo.domino.jna.constants.NoteClass;
 import com.mindoo.domino.jna.constants.Search;
 import com.mindoo.domino.jna.utils.StringUtil;
+import com.mindoo.domino.jna.virtualviews.VirtualView.CategorizationStyle;
 import com.mindoo.domino.jna.virtualviews.VirtualViewColumn.Category;
 import com.mindoo.domino.jna.virtualviews.VirtualViewColumn.Hidden;
 import com.mindoo.domino.jna.virtualviews.VirtualViewColumn.Total;
@@ -48,7 +49,7 @@ public enum VirtualViewFactory {
 	public static VirtualViewBuilder createView(VirtualViewColumn... columnsParam) {
 		return createView(Arrays.asList(columnsParam));
 	}
-	
+
 	/**
 	 * Creates a new {@link VirtualView} object with the specified columns
 	 * 
@@ -58,7 +59,7 @@ public enum VirtualViewFactory {
 	public static VirtualViewBuilder createView(List<VirtualViewColumn> columnsParam) {
 		return new VirtualViewBuilder(columnsParam);
 	}
-
+	
 	/**
 	 * Creates a new {@link VirtualView} object with the columns from the specified NotesCollection
 	 * 
@@ -117,6 +118,19 @@ public enum VirtualViewFactory {
 			return m_view;
 		}
 
+		/**
+		 * Method to chose the categorization style of the view, either
+		 * {@link CategorizationStyle#DOCUMENT_THEN_CATEGORY} (default style of Domino views) or
+		 * {@link CategorizationStyle#CATEGORY_THEN_DOCUMENT}
+		 * 
+		 * @param style categorization style
+		 * @return builder object to add more data providers
+		 */
+		public VirtualViewBuilder withCategorizationStyle(CategorizationStyle style) {
+			m_view.setCategorizationStyle(style);
+			return this;
+		}
+		
 		/**
 		 * Adds a data provider to the view that runs a formula search in a Notes database and for all matching data documents
 		 * it computes the view column values.

--- a/domino-jna/src/main/java/com/mindoo/domino/jna/virtualviews/VirtualViewNavigator.java
+++ b/domino-jna/src/main/java/com/mindoo/domino/jna/virtualviews/VirtualViewNavigator.java
@@ -316,6 +316,17 @@ public class VirtualViewNavigator {
 	 * then navigates through the view with {@link #gotoNext()}, returning
 	 * the entries as a stream. Takes the expand states into account.
 	 * 
+	 * @return stream of entries
+	 */
+	public Stream<VirtualViewEntryData> entriesForward() {
+		return entriesForward(SelectedOnly.NO);
+	}
+	
+	/**
+	 * Moves the cursor to the top of the view ({@link #gotoFirst()}) and
+	 * then navigates through the view with {@link #gotoNext()}, returning
+	 * the entries as a stream. Takes the expand states into account.
+	 * 
 	 * @param selectedOnly true to return only selected entries
 	 * @return stream of entries
 	 * @see #select(String, int, boolean)
@@ -345,8 +356,20 @@ public class VirtualViewNavigator {
 	 * then navigates through the view with {@link #gotoPrev()}, returning
 	 * the entries as a stream. Takes the expand states into account.
 	 * 
+	 * @return stream of entries
+	 */
+	public Stream<VirtualViewEntryData> entriesBackward() {
+		return entriesBackward(SelectedOnly.NO);
+	}
+	
+	/**
+	 * Moves the cursor to the end of the view ({@link #gotoLast()}) and
+	 * then navigates through the view with {@link #gotoPrev()}, returning
+	 * the entries as a stream. Takes the expand states into account.
+	 * 
 	 * @param selectedOnly true to return only selected entries
 	 * @return stream of entries
+	 * @see #select(String, int, boolean)
 	 */
 	public Stream<VirtualViewEntryData> entriesBackward(SelectedOnly selectedOnly) {
 		if (!gotoLast()) {

--- a/domino-jna/src/main/java/com/mindoo/domino/jna/virtualviews/VirtualViewNavigator.java
+++ b/domino-jna/src/main/java/com/mindoo/domino/jna/virtualviews/VirtualViewNavigator.java
@@ -1,6 +1,7 @@
 package com.mindoo.domino.jna.virtualviews;
 
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -677,6 +678,94 @@ public class VirtualViewNavigator {
 	}
 	
 	/**
+	 * Compares two position arrays like [1,2], [1,2,3] and [1,2,4]
+	 */
+	private static final Comparator<int[]> positionArrayComparator = new Comparator<int[]>() {
+		@Override
+		public int compare(int[] o1, int[] o2) {
+			int len = Math.min(o1.length, o2.length);
+			for (int i = 0; i < len; i++) {
+				if (o1[i] != o2[i]) {
+					return o1[i] - o2[i];
+				}
+			}
+			return o1.length - o2.length;
+		}
+	};
+	
+	/**
+	 * Returns all occurrences of a note id in the view in ascending order (sorted by position)
+	 * 
+	 * @param origin origin of the entry
+	 * @param noteId note id of the entry
+	 * @return stream of entries
+	 */
+	public Stream<VirtualViewEntryData> getSortedEntries(String origin, int noteId) {
+		return view
+				.getEntries(origin, noteId)
+				.stream()
+				.sorted((entry1, entry2) -> {
+					int[] pos1 = entry1.getPosition();
+					int[] pos2 = entry2.getPosition();
+					
+					return positionArrayComparator.compare(pos1, pos2);
+				})
+				.filter((currEntry) -> {
+					return viewEntryAccessCheck.isVisible(currEntry);
+				});
+	}
+
+	/**
+	 * Returns all occurrences of a note id in the view in ascending order (sorted by position)
+	 * 
+	 * @param origin origin
+	 * @param noteIds set of note ids
+	 * @return stream of entries
+	 */
+	public Stream<VirtualViewEntryData> getSortedEntries(String origin, Set<Integer> noteIds) {
+		//same as other getSortedEntries method, but for a single origin
+		return noteIds
+				.stream()
+				.flatMap((noteId) -> {
+					return view.getEntries(origin, noteId).stream();
+				})
+				.sorted((entry1, entry2) -> {
+					int[] pos1 = entry1.getPosition();
+					int[] pos2 = entry2.getPosition();
+					
+					return positionArrayComparator.compare(pos1, pos2);
+				})
+				.filter((currEntry) -> {
+					return viewEntryAccessCheck.isVisible(currEntry);
+				});
+	}
+
+	/**
+	 * Returns all occurrences of the specified note ids in the view in ascending order (sorted
+	 * by position)
+	 * 
+	 * @param noteIds set of note ids with origin
+	 * @return stream of entries
+	 */
+	public Stream<VirtualViewEntryData> getSortedEntries(Set<ScopedNoteId> noteIds) {
+		//return Stream of VirtualViewEntryData sorted by VirtualViewEntryData.getPositionStr()
+		return noteIds
+				.stream()
+				.flatMap((scopedNoteId) -> {
+					return view.getEntries(scopedNoteId.getOrigin(), scopedNoteId.getNoteId()).stream();
+				})
+				.sorted((entry1, entry2) -> {
+					int[] pos1 = entry1.getPosition();
+					int[] pos2 = entry2.getPosition();
+					
+					return positionArrayComparator.compare(pos1, pos2);
+				})
+				.filter((currEntry) -> {
+					return viewEntryAccessCheck.isVisible(currEntry);
+				});
+	}
+
+	/**
 	 * Returns the view entry at the cursor position
 	 * 
 	 * @return view entry or null if the cursor is offroad
@@ -719,7 +808,7 @@ public class VirtualViewNavigator {
 		}
 		
 		if (selectParentCategories) {
-			List<VirtualViewEntryData> entries = view.findEntries(origin, noteId);
+			List<VirtualViewEntryData> entries = view.getEntries(origin, noteId);
 			if (entries != null) {
 				VirtualViewEntryData rootEntry = view.getRoot();
 				

--- a/domino-jna/src/test/java/com/mindoo/domino/jna/test/TestVirtualView.java
+++ b/domino-jna/src/test/java/com/mindoo/domino/jna/test/TestVirtualView.java
@@ -72,7 +72,7 @@ public class TestVirtualView extends BaseJNATestClass {
 
 							new VirtualViewColumn("Total Name Length", "TotalNameLength",
 									Category.NO, Hidden.NO, ColumnSort.NONE, Total.SUM,
-									new VirtualViewColumnValueFunction<Integer>(1) {
+									new VirtualViewColumnValueFunction<Integer>(1) { // this 1 is a version number for the column function, might become relevant later when we store the index to disk
 
 								@Override
 								public Integer getValue(String origin, String itemName,

--- a/domino-jna/src/test/java/com/mindoo/domino/jna/test/TestVirtualView.java
+++ b/domino-jna/src/test/java/com/mindoo/domino/jna/test/TestVirtualView.java
@@ -145,6 +145,7 @@ public class TestVirtualView extends BaseJNATestClass {
 						.build()
 						.expandAll();
 
+				//render the view as markdown table to the console
 				new NotesMarkdownTable(nav, pWriter)
 				.addColumn(NotesMarkdownTable.EXPANDSTATE)
 				.addColumn(NotesMarkdownTable.POS)
@@ -154,7 +155,7 @@ public class TestVirtualView extends BaseJNATestClass {
 				.addAllViewColumns()
 
 				.printHeader()
-				.printRows(nav.entriesForward(SelectedOnly.NO))
+				.printRows(nav.entriesForward(SelectedOnly.NO)) // convenience function that navigates the view and returns all expanded entries as a Stream
 				.printFooter();
 
 				long nav_t1=System.currentTimeMillis();

--- a/domino-jna/src/test/java/com/mindoo/domino/jna/test/TestVirtualView.java
+++ b/domino-jna/src/test/java/com/mindoo/domino/jna/test/TestVirtualView.java
@@ -51,9 +51,16 @@ public class TestVirtualView extends BaseJNATestClass {
 				someExternalData.put("Omnis", "Omnis Boulevard 12, New York");
 
 				long update_t0=System.currentTimeMillis();
+
+				//by using "createViewOnce", we mark the view to be stored in memory, as a version "1" and to auto discard it
+				//after 1 minute of inactivity (just for testing, in production you'd use a higher value)
 				
-				VirtualView view = VirtualViewFactory.INSTANCE.createViewOnce("fakenames_origindb_namelenghts", 1,
-						1, TimeUnit.MINUTES, (id) -> {
+				//changing the version number to "2" would force a new view to be created
+				
+				VirtualView view = VirtualViewFactory.INSTANCE.createViewOnce("fakenames_origindb_namelenghts",
+						1, // version "1"
+						1, TimeUnit.MINUTES, // auto discard after 1 minute of inactivity (calling createViewOnce resets the counting)
+						(id) -> {
 					return VirtualViewFactory.createView(
 							new VirtualViewColumn("Lastname", "Lastname",
 									Category.YES, Hidden.NO, ColumnSort.ASCENDING, Total.NONE,

--- a/domino-jna/src/test/java/com/mindoo/domino/jna/test/TestVirtualView.java
+++ b/domino-jna/src/test/java/com/mindoo/domino/jna/test/TestVirtualView.java
@@ -102,6 +102,9 @@ public class TestVirtualView extends BaseJNATestClass {
 										@Override
 										public String getValue(String origin, String itemName,
 												INoteSummary columnValues) {
+											//poor man's JOIN :-)
+											//we fetch the company address from a map using the company name as key
+											
 											String companyName = columnValues.getAsString("CompanyName", "");
 											return someExternalData.getOrDefault(companyName, "");
 										}
@@ -111,7 +114,7 @@ public class TestVirtualView extends BaseJNATestClass {
 									Category.NO, Hidden.NO, ColumnSort.NONE, Total.NONE,
 									"LastMod"),
 
-							//rquired to have the CompanyName value available in the Java column function
+							//required to have the CompanyName value available in the summary buffer so that the Java column function can use it
 							new VirtualViewColumn("Company Name", "CompanyName",
 									Category.NO, Hidden.YES, ColumnSort.NONE, Total.NONE,
 									"CompanyName")

--- a/domino-jna/src/test/java/com/mindoo/domino/jna/test/TestVirtualView.java
+++ b/domino-jna/src/test/java/com/mindoo/domino/jna/test/TestVirtualView.java
@@ -53,13 +53,13 @@ public class TestVirtualView extends BaseJNATestClass {
 				long update_t0=System.currentTimeMillis();
 
 				//by using "createViewOnce", we mark the view to be stored in memory, as a version "1" and to auto discard it
-				//after 1 minute of inactivity (just for testing, in production you'd use a higher value)
+				//after 5 minute of inactivity (just for testing, in production you'd use a higher value)
 				
 				//changing the version number to "2" would force a new view to be created
 				
 				VirtualView view = VirtualViewFactory.INSTANCE.createViewOnce("fakenames_origindb_namelenghts",
 						1, // version "1"
-						1, TimeUnit.MINUTES, // auto discard after 1 minute of inactivity (calling createViewOnce resets the counting)
+						5, TimeUnit.MINUTES, // auto discard after 5 minute of inactivity (calling createViewOnce resets the counting)
 						(id) -> {
 					return VirtualViewFactory.createView(
 							new VirtualViewColumn("Lastname", "Lastname",

--- a/domino-target/pom.xml
+++ b/domino-target/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.mindoo.domino</groupId>
 	<artifactId>domino-target</artifactId>
-	<version>0.9.42</version>
+	<version>0.9.51</version>
 	<packaging>pom</packaging>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.mindoo.domino</groupId>
 	<artifactId>domino-jna-base</artifactId>
-	<version>0.9.49-SNAPSHOT</version>
+	<version>0.9.50-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Domino JNA Base project</name>
@@ -23,8 +23,8 @@
 		<domino.version>11.0.0</domino.version>
 		<jna.version>4.5.1</jna.version>
 		<maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
-		<nexus-staging-maven-plugin.version>1.5.1</nexus-staging-maven-plugin.version>
-		<maven-source-plugin.version>3.2.1</maven-source-plugin.version>
+		<nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
+		<maven-source-plugin.version>3.3.1</maven-source-plugin.version>
 		<maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
 		<maven-surefire-plugin.version>2.19.1</maven-surefire-plugin.version>
 		<maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.mindoo.domino</groupId>
 	<artifactId>domino-jna-base</artifactId>
-	<version>0.9.50-SNAPSHOT</version>
+	<version>0.9.51-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Domino JNA Base project</name>

--- a/standalone-app-sample/pom.xml
+++ b/standalone-app-sample/pom.xml
@@ -9,7 +9,7 @@
 		<dependency>
 			<groupId>com.mindoo.domino</groupId>
 			<artifactId>domino-jna</artifactId>
-			<version>0.9.49-SNAPSHOT</version>
+			<version>0.9.50-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/standalone-app-sample/pom.xml
+++ b/standalone-app-sample/pom.xml
@@ -9,7 +9,7 @@
 		<dependency>
 			<groupId>com.mindoo.domino</groupId>
 			<artifactId>domino-jna</artifactId>
-			<version>0.9.50-SNAPSHOT</version>
+			<version>0.9.51-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 	<build>


### PR DESCRIPTION
# Virtual Views
* made virtual views more closely match Domino views, e.g. regarding ordering of documents and categories
* fixed handling of empty string for category values ("(Not categorized)"), now sorted to the bottom
* fixed comparison of datetime categoryvalues with missing dates (resulting in empty strings)
* new option to change the order of categories and documents in categorized virtual views when constructing the virtual view
* new VirtualViewNavigator methods to sort a set of note ids based on the view order without a full view scan
* added method VirtualViewEntryData.getIndentLevels() for multilevel category values
* excluded docs with $ref field by default from Virtual Views, can be overridden if you really want to analyze them
* more example code in class TestVirtualViews
* bugfixes